### PR TITLE
feat: make the package compatible with go error package

### DIFF
--- a/error.go
+++ b/error.go
@@ -68,7 +68,7 @@ type Error struct {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The stacktrace will point to the line of code that
 // called New.
-func New(e interface{}) *Error {
+func New(e interface{}) error {
 	var err error
 
 	switch e := e.(type) {
@@ -90,7 +90,7 @@ func New(e interface{}) *Error {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The skip parameter indicates how far up the stack
 // to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
-func Wrap(e interface{}, skip int) *Error {
+func Wrap(e interface{}, skip int) error {
 	if e == nil {
 		return nil
 	}
@@ -120,12 +120,12 @@ func Wrap(e interface{}, skip int) *Error {
 // error message when calling Error(). The skip parameter indicates how far
 // up the stack to start the stacktrace. 0 is from the current call,
 // 1 from its caller, etc.
-func WrapPrefix(e interface{}, prefix string, skip int) *Error {
+func WrapPrefix(e interface{}, prefix string, skip int) error {
 	if e == nil {
 		return nil
 	}
 
-	err := Wrap(e, 1+skip)
+	err, _ := Wrap(e, 1+skip).(*Error)
 
 	if err.prefix != "" {
 		prefix = fmt.Sprintf("%s: %s", prefix, err.prefix)
@@ -142,7 +142,7 @@ func WrapPrefix(e interface{}, prefix string, skip int) *Error {
 // Errorf creates a new error with the given message. You can use it
 // as a drop-in replacement for fmt.Errorf() to provide descriptive
 // errors in return values.
-func Errorf(format string, a ...interface{}) *Error {
+func Errorf(format string, a ...interface{}) error {
 	return Wrap(fmt.Errorf(format, a...), 1)
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -22,7 +22,7 @@ func BenchmarkStackFormat(b *testing.B) {
 				}
 
 				e := Errorf("hi")
-				_ = string(e.Stack())
+				_ = string(e.(*Error).Stack())
 			}()
 
 			a()
@@ -63,14 +63,14 @@ func TestStackFormat(t *testing.T) {
 
 		e, expected := Errorf("hi"), callers()
 
-		bs := [][]uintptr{e.stack, expected}
+		bs := [][]uintptr{e.(*Error).stack, expected}
 
 		if err := compareStacks(bs[0], bs[1]); err != nil {
 			t.Errorf("Stack didn't match")
 			t.Errorf(err.Error())
 		}
 
-		stack := string(e.Stack())
+		stack := string(e.(*Error).Stack())
 
 		if !strings.Contains(stack, "a: b(5)") {
 			t.Errorf("Stack trace does not contain source line: 'a: b(5)'")
@@ -93,7 +93,7 @@ func TestSkipWorks(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bs := [][]uintptr{Wrap("hi", 2).stack, callersSkip(2)}
+		bs := [][]uintptr{Wrap("hi", 2).(*Error).stack, callersSkip(2)}
 
 		if err := compareStacks(bs[0], bs[1]); err != nil {
 			t.Errorf("Stack didn't match")
@@ -118,14 +118,14 @@ func TestNew(t *testing.T) {
 		t.Errorf("Wrong message")
 	}
 
-	bs := [][]uintptr{New("foo").stack, callers()}
+	bs := [][]uintptr{New("foo").(*Error).stack, callers()}
 
 	if err := compareStacks(bs[0], bs[1]); err != nil {
 		t.Errorf("Stack didn't match")
 		t.Errorf(err.Error())
 	}
 
-	if err.ErrorStack() != err.TypeName()+" "+err.Error()+"\n"+string(err.Stack()) {
+	if err.(*Error).ErrorStack() != err.(*Error).TypeName()+" "+err.Error()+"\n"+string(err.(*Error).Stack()) {
 		t.Errorf("ErrorStack is in the wrong format")
 	}
 }
@@ -190,7 +190,7 @@ func TestWrapPrefixError(t *testing.T) {
 		t.Errorf("Constructor with an error failed")
 	}
 
-	prefixed := WrapPrefix(e, "prefix", 0)
+	prefixed := WrapPrefix(e, "prefix", 0).(*Error)
 	original := e.(*Error)
 
 	if prefixed.Err != original.Err || !reflect.DeepEqual(prefixed.stack, original.stack) || !reflect.DeepEqual(prefixed.frames, original.frames) || prefixed.Error() != "prefix: prefix: hi" {


### PR DESCRIPTION
The following commit bring back https://github.com/go-errors/errors/pull/33 